### PR TITLE
modify _collate with recursive call to support lists of dicts

### DIFF
--- a/pyblaze/nn/engine/base.py
+++ b/pyblaze/nn/engine/base.py
@@ -596,8 +596,9 @@ class Engine(TrainingCallback, PredictionCallback, ABC):
         ref = items[0]
         if isinstance(ref, dict):
             return {key: torch.cat([v[key] for v in items]) for key in ref.keys()}
+        # recursive call of _collate for a more generic functionality
         if isinstance(ref, (list, tuple)):
-            return tuple(torch.cat([v[i] for v in items]) for i in range(len(ref)))
+            return tuple(self._collate([v[i] for v in items]) for i in range(len(ref)))
         return torch.cat(items)
 
     def _process_metric(self, metric):


### PR DESCRIPTION
- _collate is causing issues when working with inputs/targets containing dictionaries in combination with the MLEEngine and its method _merge_out_target_x
- _merge_out_target_x finally produces a tuple (x, target)
- when collating the evaluations, the condition checking for "isinstance(ref, dict)" is not sufficient to fully support dictionaries
- can be easily fixed with a recursive call of self._collate and generalizes to arbitrary combinations of lists, tuples, dictionaries and Tensors. 